### PR TITLE
add basic string type lexing + tests

### DIFF
--- a/internals/lexer/lexer_test.go
+++ b/internals/lexer/lexer_test.go
@@ -10,6 +10,7 @@ func TestLexer(t *testing.T) {
 	input := `
     fn main() {
         print(1 + 1);
+        print("Hello World!");
     }
     -*/%;
     `
@@ -27,6 +28,12 @@ func TestLexer(t *testing.T) {
 		{Literal: "1", Type: INT},
 		{Literal: "+", Type: BIN_PLUS},
 		{Literal: "1", Type: INT},
+		{Literal: ")", Type: CLOSE_PARAN},
+		{Literal: ";", Type: SEMICOLON},
+
+		{Literal: "print", Type: IDENT},
+		{Literal: "(", Type: OPEN_PARAN},
+		{Literal: "Hello World!", Type: STR},
 		{Literal: ")", Type: CLOSE_PARAN},
 		{Literal: ";", Type: SEMICOLON},
 

--- a/internals/lexer/lexer_tokenizer.go
+++ b/internals/lexer/lexer_tokenizer.go
@@ -24,6 +24,9 @@ func (l *Lexer) NextToken() token.Token {
 	case NULL_CHAR:
 		tok = token.Token{Literal: "", Type: token.EOF, Pos: l.pos}
 
+	case '"', '`', '\'':
+		tok = l.read_string()
+
 	case '+':
 		{
 			// TODO: handle prefix ++ in here
@@ -50,6 +53,28 @@ func (l *Lexer) NextToken() token.Token {
 	l.read_char()
 
 	return tok
+}
+
+func (l *Lexer) read_string() token.Token {
+	strType := l.ch
+	pos := l.pos
+	lit := ""
+	MAX_STRING_SIZE := 256 // FIXME: Move this outside?
+
+	for len(lit) <= MAX_STRING_SIZE {
+		l.read_char()
+		if l.ch == '\n' {
+			panic("newline char in regular str | your retarded ass doesn't understand common fucking strings")
+		} else if l.ch == strType {
+			break
+		} else if len(lit) >= MAX_STRING_SIZE {
+			panic("len(str) > 256 or string wasn't closed | bro really thought this was javascript")
+		} else {
+			lit += string(l.ch)
+		}
+	}
+
+	return token.Token{Literal: lit, Type: token.STR, Pos: pos}
 }
 
 func (l *Lexer) read_number() token.Token {

--- a/internals/token/token.go
+++ b/internals/token/token.go
@@ -22,6 +22,7 @@ const (
 
 	// types
 	INT
+    STR
 	FUNC
 
 	// operator


### PR DESCRIPTION
`Lexer.read_string()` implemented. Test added in the preexisting `lexer_test.TestLexer()`

> [!IMPORTANT]
> Illegal characters (if any) need to be handled.
> Parsing for the `string` type yet to be implemented